### PR TITLE
Make a gif exists before trying to access it

### DIFF
--- a/src/components/ErrorPage/index.jsx
+++ b/src/components/ErrorPage/index.jsx
@@ -119,7 +119,7 @@ export const ErrorPage = ({
                         <Button level={1} url="/">Return to home</Button>
                     </CTAContainer>
                 </Content>
-                {gifs &&
+                {gifs && gifs.length > random &&
                     <Image>
                         <img src={gifs[random].url} alt={gifs[random].alt} />
                     </Image>


### PR DESCRIPTION
When a very bad error has occurred there are no gifs as these are provided by CMS but we might not have been able to get to CMS.  In this case the gifs prop is an empty array.  You need to check not only that gifs exists but that its got something in it.