### PR TITLE
D20-749: Added an onClick option to the FileDownload

### DIFF
--- a/src/components/DownloadableFiles/FileDownload/index.jsx
+++ b/src/components/DownloadableFiles/FileDownload/index.jsx
@@ -77,7 +77,8 @@ export const FileDownload = ({
     title,
     type,
     url,
-    size
+    size,
+    onClick
 }) => {
     const [isHovered, setIsHovered] = useState(false)
 
@@ -88,6 +89,7 @@ export const FileDownload = ({
                 download
                 onMouseEnter={() => setIsHovered(true)}
                 onMouseLeave={() => setIsHovered(false)}
+		onClick={onClick}
             >
                 <DownloadFileIcon colourFill={isHovered ? theme.dark : theme.primary} />
                 <FileDetails className="file-details">


### PR DESCRIPTION
Hi Chris, can you check this is OK?

This is to allow me to pass in data layer push events to the download link with the intention that the property looks something like this:

onClick = "dataLayer.push({'event': 'Download', 'filename': 'some-file', 'filetype': 'PDF', 'filesize': '1024');"